### PR TITLE
Fix wrong string comparison (object instead of value)

### DIFF
--- a/src/main/java/org/openhab/binding/helios/internal/HeliosBinding.java
+++ b/src/main/java/org/openhab/binding/helios/internal/HeliosBinding.java
@@ -182,7 +182,7 @@ public class HeliosBinding extends AbstractActiveBinding<HeliosBindingProvider> 
 		switch (heliosType) {
 			case HeliosVariable.TYPE_INTEGER:
 			case HeliosVariable.TYPE_FLOAT:
-				if (dataTypes.contains(OnOffType.class)) return heliosValue == "1" ? OnOffType.ON : OnOffType.OFF;
+				if (dataTypes.contains(OnOffType.class)) return heliosValue.equals("1") ? OnOffType.ON : OnOffType.OFF;
 				else return DecimalType.valueOf(heliosValue);
 			case HeliosVariable.TYPE_STRING:
 				return StringType.valueOf(heliosValue);


### PR DESCRIPTION
The wrong string comparison causes OnOff variables to always have the value "Off".